### PR TITLE
Add staging deploy workflow and environment-aware Firebase config

### DIFF
--- a/.github/workflows/build-deploy-staging-on-push.yml
+++ b/.github/workflows/build-deploy-staging-on-push.yml
@@ -1,0 +1,43 @@
+name: Build and Deploy Process Audio (Staging)
+
+env:
+  PYTHONWARNINGS: 'ignore' # suppress warnings from app engine libraries
+
+on:
+  push:
+    branches:
+      - staging
+  workflow_dispatch:
+
+concurrency:
+  group: process-audio-staging-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GCP credentials
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Ensure Artifact Registry repository exists
+        run: |
+          gcloud artifacts repositories describe process-audio-repo \
+            --project=urm-app-staging \
+            --location=us-central1 >/dev/null 2>&1 || \
+          gcloud artifacts repositories create process-audio-repo \
+            --project=urm-app-staging \
+            --location=us-central1 \
+            --repository-format=docker
+
+      - name: Trigger Cloud Build (staging)
+        run: |
+          gcloud beta builds submit \
+            --project=urm-app-staging \
+            --config cloudbuild.yaml \
+            --substitutions=TRIGGER_NAME="github-actions-staging",BRANCH_NAME="${{ github.ref_name }}",COMMIT_SHA="${{ github.sha }}",REPO_NAME="${{ github.repository }}",REPO_FULL_NAME="${{ github.repository }}",TAG_NAME="${{ github.ref_name }}",REF_NAME="${{ github.ref_name }}",_PROJECT_ID="urm-app-staging",_REGION="us-central1",_AR_REPO="process-audio-repo",_IMAGE_NAME="process-audio",_SERVICE_NAME="process-audio-staging",_FIREBASE_PROJECT_ID="urm-app-staging",_FIREBASE_STORAGE_BUCKET="urm-app-staging.appspot.com",_FIREBASE_DATABASE_URL="https://urm-app-staging-815ca.firebaseio.com/"

--- a/.github/workflows/build-deploy-staging-on-push.yml
+++ b/.github/workflows/build-deploy-staging-on-push.yml
@@ -25,16 +25,6 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Ensure Artifact Registry repository exists
-        run: |
-          gcloud artifacts repositories describe process-audio-repo \
-            --project=urm-app-staging \
-            --location=us-central1 >/dev/null 2>&1 || \
-          gcloud artifacts repositories create process-audio-repo \
-            --project=urm-app-staging \
-            --location=us-central1 \
-            --repository-format=docker
-
       - name: Trigger Cloud Build (staging)
         run: |
           gcloud beta builds submit \

--- a/.github/workflows/build-deploy-staging-on-push.yml
+++ b/.github/workflows/build-deploy-staging-on-push.yml
@@ -16,6 +16,12 @@ concurrency:
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: urm-app-staging
+      REGION: us-central1
+      AR_REPO: process-audio-repo
+      IMAGE_NAME: process-audio
+      SERVICE_NAME: process-audio-staging
 
     steps:
       - uses: actions/checkout@v4
@@ -25,9 +31,29 @@ jobs:
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
-      - name: Trigger Cloud Build (staging)
+      - name: Configure Docker auth for Artifact Registry
+        run: gcloud auth configure-docker "${{ env.REGION }}-docker.pkg.dev" --quiet
+
+      - name: Build and push container image
+        env:
+          IMAGE_URI: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
         run: |
-          gcloud beta builds submit \
-            --project=urm-app-staging \
-            --config cloudbuild.yaml \
-            --substitutions=TRIGGER_NAME="github-actions-staging",BRANCH_NAME="${{ github.ref_name }}",COMMIT_SHA="${{ github.sha }}",REPO_NAME="${{ github.repository }}",REPO_FULL_NAME="${{ github.repository }}",TAG_NAME="${{ github.ref_name }}",REF_NAME="${{ github.ref_name }}",_PROJECT_ID="urm-app-staging",_REGION="us-central1",_AR_REPO="process-audio-repo",_IMAGE_NAME="process-audio",_SERVICE_NAME="process-audio-staging",_FIREBASE_PROJECT_ID="urm-app-staging",_FIREBASE_STORAGE_BUCKET="urm-app-staging.appspot.com",_FIREBASE_DATABASE_URL="https://urm-app-staging-815ca.firebaseio.com/"
+          docker build -t "${IMAGE_URI}" .
+          docker push "${IMAGE_URI}"
+
+      - name: Deploy Cloud Run service (staging)
+        env:
+          IMAGE_URI: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        run: |
+          gcloud run deploy "${SERVICE_NAME}" \
+            --project="${PROJECT_ID}" \
+            --image="${IMAGE_URI}" \
+            --region="${REGION}" \
+            --platform=managed \
+            --cpu=4 \
+            --memory=4Gi \
+            --timeout=1800 \
+            --port=8080 \
+            --set-env-vars="NODE_ENV=production,FIREBASE_PROJECT_ID=urm-app-staging,FIREBASE_STORAGE_BUCKET=urm-app-staging.appspot.com,FIREBASE_DATABASE_URL=https://urm-app-staging-815ca.firebaseio.com/" \
+            --min-instances=1 \
+            --max-instances=10

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,13 +11,13 @@ steps:
         '--build-arg',
         'CACHEBUST=${COMMIT_SHA}', # force latest yt-dlp layer
         '-t',
-        'us-central1-docker.pkg.dev/urm-app/process-audio-repo/process-audio:${COMMIT_SHA}',
+        '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}',
         '.',
       ]
 
   # Step 2: Push Docker image to Artifact Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'us-central1-docker.pkg.dev/urm-app/process-audio-repo/process-audio:${COMMIT_SHA}']
+    args: ['push', '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}']
 
   # Step 3: Deploy to Cloud Run (private service)
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -26,11 +26,13 @@ steps:
       [
         'run',
         'deploy',
-        'process-audio',
+        '${_SERVICE_NAME}',
+        '--project',
+        '${_PROJECT_ID}',
         '--image',
-        'us-central1-docker.pkg.dev/urm-app/process-audio-repo/process-audio:${COMMIT_SHA}',
+        '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}',
         '--region',
-        'us-central1',
+        '${_REGION}',
         '--platform',
         'managed',
         '--cpu',
@@ -43,7 +45,19 @@ steps:
         '1',
         '--max-instances',
         '10',
+        '--set-env-vars',
+        'NODE_ENV=production,FIREBASE_PROJECT_ID=${_FIREBASE_PROJECT_ID},FIREBASE_STORAGE_BUCKET=${_FIREBASE_STORAGE_BUCKET},FIREBASE_DATABASE_URL=${_FIREBASE_DATABASE_URL}',
       ]
 
 images:
-  - 'us-central1-docker.pkg.dev/urm-app/process-audio-repo/process-audio:${COMMIT_SHA}'
+  - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_AR_REPO}/${_IMAGE_NAME}:${COMMIT_SHA}'
+
+substitutions:
+  _PROJECT_ID: 'urm-app'
+  _REGION: 'us-central1'
+  _AR_REPO: 'process-audio-repo'
+  _IMAGE_NAME: 'process-audio'
+  _SERVICE_NAME: 'process-audio'
+  _FIREBASE_PROJECT_ID: 'urm-app'
+  _FIREBASE_STORAGE_BUCKET: 'urm-app.appspot.com'
+  _FIREBASE_DATABASE_URL: 'https://urm-app-default-rtdb.firebaseio.com/'

--- a/src/firebaseAdmin.ts
+++ b/src/firebaseAdmin.ts
@@ -2,8 +2,29 @@ import firebaseAdmin from 'firebase-admin';
 import { applicationDefault } from 'firebase-admin/app';
 import logger from './WinstonLogger';
 const isDevelopment = process.env.NODE_ENV === 'development';
+const DEFAULT_FIREBASE_PROJECT_ID = 'urm-app';
+
+const resolveFirebaseProjectId = (): string =>
+  process.env.FIREBASE_PROJECT_ID ||
+  process.env.GOOGLE_CLOUD_PROJECT ||
+  process.env.GCLOUD_PROJECT ||
+  process.env.PROJECT_ID ||
+  DEFAULT_FIREBASE_PROJECT_ID;
+
+const resolveStorageBucket = (projectId: string): string => process.env.FIREBASE_STORAGE_BUCKET || `${projectId}.appspot.com`;
+
+const resolveDatabaseUrl = (projectId: string): string => {
+  const databaseInstance = process.env.FIREBASE_DATABASE_INSTANCE || `${projectId}-default-rtdb`;
+  if (isDevelopment && process.env.FIREBASE_DATABASE_EMULATOR_HOST) {
+    return `http://${process.env.FIREBASE_DATABASE_EMULATOR_HOST}?ns=${databaseInstance}`;
+  }
+  return process.env.FIREBASE_DATABASE_URL || `https://${databaseInstance}.firebaseio.com/`;
+};
 
 if (!firebaseAdmin.apps.length) {
+  const firebaseProjectId = resolveFirebaseProjectId();
+  const storageBucket = resolveStorageBucket(firebaseProjectId);
+
   if (isDevelopment) {
     logger.info('Setting Admin SDK to use emulator');
     // Use environment variables if set, otherwise default to localhost
@@ -44,20 +65,18 @@ if (!firebaseAdmin.apps.length) {
       },
     });
   } else {
-    logger.info('Using production Firebase services', {
-      storageBucket: 'urm-app.appspot.com',
-      databaseURL: 'https://urm-app-default-rtdb.firebaseio.com/',
+    logger.info('Using non-emulator Firebase services', {
+      firebaseProjectId,
+      storageBucket,
+      databaseURL: process.env.FIREBASE_DATABASE_URL || '(derived from project)',
     });
   }
 
   // Configure databaseURL for emulator or production
-  const databaseURL =
-    isDevelopment && process.env.FIREBASE_DATABASE_EMULATOR_HOST
-      ? `http://${process.env.FIREBASE_DATABASE_EMULATOR_HOST}?ns=urm-app-default-rtdb`
-      : 'https://urm-app-default-rtdb.firebaseio.com/';
+  const databaseURL = resolveDatabaseUrl(firebaseProjectId);
 
   if (isDevelopment) {
-    logger.info('Database URL configured', { databaseURL });
+    logger.info('Database URL configured', { firebaseProjectId, storageBucket, databaseURL });
   }
 
   // In development with emulators, we don't need real credentials
@@ -68,8 +87,8 @@ if (!firebaseAdmin.apps.length) {
     databaseURL: string;
     credential?: ReturnType<typeof applicationDefault>;
   } = {
-    projectId: 'urm-app', // Required for emulators to work properly
-    storageBucket: 'urm-app.appspot.com',
+    projectId: firebaseProjectId, // Required for emulators to work properly
+    storageBucket,
     databaseURL,
   };
 


### PR DESCRIPTION
## Summary
- add staging GitHub Actions workflow for `staging` branch deploys
- make Firebase runtime config environment-aware in `firebaseAdmin.ts`
- parameterize `cloudbuild.yaml` for project/service/image/runtime env inputs
- switch staging workflow to direct Docker build/push + Cloud Run deploy path

## Staging details
- service: `process-audio-staging`
- project: `urm-app-staging`
- region: `us-central1`
- image repo: `process-audio-repo`

## Validation
- `pnpm build` succeeded locally
- staging workflow run succeeded:
  - https://github.com/upperroommedia/process-audio-cloud-run/actions/runs/22842765199